### PR TITLE
難易度設定を追加

### DIFF
--- a/src/app/_component/GameClearModal.tsx
+++ b/src/app/_component/GameClearModal.tsx
@@ -13,10 +13,12 @@ import { useRouter } from "next/navigation";
  * @returns
  */
 export const GameClearModal = ({
+	mode,
 	timeElapsed,
 	isGameComplete,
 	setIsGameComplete,
 }: {
+	mode: "easy" | "normal" | "hard";
 	timeElapsed: number;
 	isGameComplete: boolean;
 	setIsGameComplete: React.Dispatch<React.SetStateAction<boolean>>;
@@ -38,6 +40,11 @@ export const GameClearModal = ({
 		>
 			<Stack>
 				<Text mb={16}>
+					{mode === "easy"
+						? "かんたん"
+						: mode === "normal"
+							? "ふつう"
+							: "むずかしい"}
 					クリアおめでとう~!(^○^)
 					<br />
 					かかった時間は{timeElapsed}秒です

--- a/src/app/_component/GameProgress.tsx
+++ b/src/app/_component/GameProgress.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Group, Text } from "@mantine/core";
+import { Flex, Group, rem, Text } from "@mantine/core";
+import { TbClock } from "react-icons/tb";
 
 /**
  * ゲームの進行状況を表示するコンポーネント
@@ -10,9 +11,11 @@ import { Group, Text } from "@mantine/core";
  * @returns
  */
 export const GameProgress = ({
+	mode,
 	errorCells,
 	timeElapsed,
 }: {
+	mode: "easy" | "normal" | "hard";
 	errorCells: number;
 	timeElapsed: number;
 }) => {
@@ -25,12 +28,24 @@ export const GameProgress = ({
 	return (
 		<Group
 			p={8}
-			justify="right"
+			justify="space-between"
 			my={8}
 			style={{ boxShadow: "0 0 4px #7e7e7e", borderRadius: 4 }}
 		>
-			<Text>ミス数: {errorCells}/3</Text>
-			<Text>経過時間:{formatTime(timeElapsed)}秒</Text>
+			<Text>
+				{mode === "easy"
+					? "かんたん"
+					: mode === "normal"
+						? "ふつう"
+						: "むずかしい"}
+			</Text>
+			<Group>
+				<Text>ミス数: {errorCells}/3</Text>
+				<Flex align={"center"} gap={4}>
+					<TbClock style={{ width: rem(18), height: rem(18) }} />
+					{formatTime(timeElapsed)}秒
+				</Flex>
+			</Group>
 		</Group>
 	);
 };

--- a/src/app/_component/GameStartModal.tsx
+++ b/src/app/_component/GameStartModal.tsx
@@ -2,7 +2,6 @@
 
 import {
 	Button,
-	Container,
 	Flex,
 	Modal,
 	Radio,
@@ -34,36 +33,50 @@ export const GameStartModal = ({
 	};
 
 	return (
-		<Modal withCloseButton={false} opened={true} onClose={() => {}}>
-			<Container>
-				<Title fz={{ base: 24, md: "h2" }}>数独アプリ</Title>
+		<Modal.Root opened={true} onClose={() => {}}>
+			<Modal.Overlay />
+			<Modal.Content
+				p={{
+					base: 12,
+					md: 24,
+				}}
+			>
+				<Modal.Body>
+					<Title fz={{ base: 24, md: "h2" }}>数独アプリ</Title>
 
-				<Text my={16}>
-					数独は、1から9までの数字を使って、
-					<br />
-					各行、各列、各3×3のブロックに、
-					<br />
-					それぞれ1から9までの数字を1回ずつだけ入れて、
-					<br />
-					すべてのマスを埋めるパズルです。
-				</Text>
+					<Text my={16}>
+						数独は、1から9までの数字を使って、
+						<br />
+						各行、各列、各3×3のブロックに、
+						<br />
+						それぞれ1から9までの数字を1回ずつだけ入れて、
+						<br className="sp-br" />
+						すべてのマスを埋めるパズルです。
+					</Text>
 
-				<RadioGroup
-					value={value}
-					onChange={setValue}
-					label="難易度"
-					required
-					my={24}
-				>
-					<Flex gap={8} my={8}>
-						<Radio label="かんたん" value="easy" />
-						<Radio label="ふつう" value="normal" />
-						<Radio label="むずかしい" value="hard" />
-					</Flex>
-				</RadioGroup>
+					<RadioGroup
+						value={value}
+						onChange={setValue}
+						label="難易度を選んでね"
+						my={24}
+					>
+						<Flex
+							gap={8}
+							my={8}
+							direction={{
+								base: "column",
+								md: "row",
+							}}
+						>
+							<Radio label="かんたん" value="easy" />
+							<Radio label="ふつう" value="normal" />
+							<Radio label="むずかしい" value="hard" />
+						</Flex>
+					</RadioGroup>
 
-				<Button onClick={handleStart}>ゲームスタート</Button>
-			</Container>
-		</Modal>
+					<Button onClick={handleStart}>ゲームスタート</Button>
+				</Modal.Body>
+			</Modal.Content>
+		</Modal.Root>
 	);
 };

--- a/src/app/_component/GameStartModal.tsx
+++ b/src/app/_component/GameStartModal.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { Button, Container, Modal, Text, Title } from "@mantine/core";
+import {
+	Button,
+	Container,
+	Flex,
+	Modal,
+	Radio,
+	RadioGroup,
+	Stack,
+	Text,
+	Title,
+} from "@mantine/core";
+import { useState } from "react";
 
 /**
  * ゲーム開始時に表示するモーダル
@@ -11,9 +22,18 @@ import { Button, Container, Modal, Text, Title } from "@mantine/core";
  */
 export const GameStartModal = ({
 	setIsStart,
+	setMode,
 }: {
 	setIsStart: () => void;
+	setMode: (mode: "easy" | "normal" | "hard") => void;
 }) => {
+	const [value, setValue] = useState("easy");
+
+	const handleStart = () => {
+		setIsStart();
+		setMode(value as "easy" | "normal" | "hard");
+	};
+
 	return (
 		<Modal withCloseButton={false} opened={true} onClose={() => {}}>
 			<Container>
@@ -29,11 +49,25 @@ export const GameStartModal = ({
 					すべてのマスを埋めるパズルです。
 				</Text>
 
-				<Button onClick={setIsStart}>ゲームスタート</Button>
+				<RadioGroup
+					value={value}
+					onChange={setValue}
+					label="難易度"
+					required
+					my={24}
+				>
+					<Flex gap={8} my={8}>
+						<Radio label="かんたん" value="easy" />
+						<Radio label="ふつう" value="normal" />
+						<Radio label="むずかしい" value="hard" />
+					</Flex>
+				</RadioGroup>
 
-				<Text c="pink" fw={"bold"} my={16}>
+				<Button onClick={handleStart}>ゲームスタート</Button>
+
+				{/* <Text c="pink" fw={"bold"} my={16}>
 					難易度設定は開発中~
-				</Text>
+				</Text> */}
 			</Container>
 		</Modal>
 	);

--- a/src/app/_component/GameStartModal.tsx
+++ b/src/app/_component/GameStartModal.tsx
@@ -7,7 +7,6 @@ import {
 	Modal,
 	Radio,
 	RadioGroup,
-	Stack,
 	Text,
 	Title,
 } from "@mantine/core";
@@ -37,7 +36,7 @@ export const GameStartModal = ({
 	return (
 		<Modal withCloseButton={false} opened={true} onClose={() => {}}>
 			<Container>
-				<Title fz={{ base: 24, md: "h2" }}>まいこの数独アプリ</Title>
+				<Title fz={{ base: 24, md: "h2" }}>数独アプリ</Title>
 
 				<Text my={16}>
 					数独は、1から9までの数字を使って、
@@ -64,10 +63,6 @@ export const GameStartModal = ({
 				</RadioGroup>
 
 				<Button onClick={handleStart}>ゲームスタート</Button>
-
-				{/* <Text c="pink" fw={"bold"} my={16}>
-					難易度設定は開発中~
-				</Text> */}
 			</Container>
 		</Modal>
 	);

--- a/src/app/_component/SudokuInit.tsx
+++ b/src/app/_component/SudokuInit.tsx
@@ -191,7 +191,7 @@ export const SudokuInit = () => {
 								h={{ base: 30, md: 48 }}
 								fz={{ base: "xs", md: "lg" }}
 								p={{ base: "xs", md: "sm" }}
-								c="lime"
+								c={disableNumberCounts.get(number) === 9 ? "gray" : "lime"}
 								fw="bold"
 							>
 								{number}

--- a/src/app/_component/SudokuInit.tsx
+++ b/src/app/_component/SudokuInit.tsx
@@ -12,6 +12,7 @@ import { GameProgress } from "./GameProgress";
 
 export const SudokuInit = () => {
 	const [isStart, setIsStart] = useState<boolean>(false);
+	const [mode, setMode] = useState<"easy" | "normal" | "hard">("easy");
 	const [board, setBoard] = useState<number[][]>([]);
 	const [selectedCell, setSelectedCell] = useState<{
 		row: number;
@@ -150,10 +151,14 @@ export const SudokuInit = () => {
 	return (
 		<div className="">
 			{!isStart ? (
-				<GameStartModal setIsStart={() => setIsStart(true)} />
+				<GameStartModal setIsStart={() => setIsStart(true)} setMode={setMode} />
 			) : (
 				<>
-					<GameProgress errorCells={errorCount} timeElapsed={timeElapsed} />
+					<GameProgress
+						mode={mode}
+						errorCells={errorCount}
+						timeElapsed={timeElapsed}
+					/>
 
 					<SudokuBoard
 						board={board}

--- a/src/app/_component/SudokuInit.tsx
+++ b/src/app/_component/SudokuInit.tsx
@@ -203,6 +203,7 @@ export const SudokuInit = () => {
 					<GameOverModal isGameOver={isGameOver} />
 					{/* ゲームクリアモーダル */}
 					<GameClearModal
+						mode={mode}
 						timeElapsed={timeElapsed}
 						isGameComplete={isGameComplete}
 						setIsGameComplete={setIsGameComplete}

--- a/src/app/_component/SudokuInit.tsx
+++ b/src/app/_component/SudokuInit.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { generateSudoku, isValid } from "@/util/sudoke";
-import { ActionIcon, Button, Group, Text, UnstyledButton } from "@mantine/core";
+import { ActionIcon, Group, UnstyledButton } from "@mantine/core";
 import { useCallback, useEffect, useState } from "react";
 import { TbTrash } from "react-icons/tb";
 import { SudokuBoard } from "./SudokuBoard";
@@ -31,14 +31,14 @@ export const SudokuInit = () => {
 	// ここに数独のロジックを書く
 	useEffect(() => {
 		if (!isStart) return;
-		const generateBoard = generateSudoku();
+		const generateBoard = generateSudoku(mode);
 		setBoard(generateBoard);
 		calculateNumberCounts(generateBoard);
 
 		setSelectedCell(null);
 		setErrorCells([]);
 		setIsTimerRunning(true);
-	}, [isStart]);
+	}, [isStart, mode]);
 
 	const calculateNumberCounts = (board: number[][]) => {
 		const counts = new Map<number, number>();
@@ -114,7 +114,7 @@ export const SudokuInit = () => {
 					setErrorCells((prev) =>
 						prev.filter((cell) => cell !== `${row}-${col}`),
 					);
-					setErrorCount((prev) => prev - 1); // エラーカウントを減少
+					if (errorCount > 0) setErrorCount((prev) => prev - 1); // エラーカウントを減少
 					setSelectedCell(null); // 選択解除
 					calculateNumberCounts(newBoard);
 				} else {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,5 @@
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
-body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))) rgb(var(--background-start-rgb));
-}
-
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
+@media (max-width: 599px) {
+  .sp-br {
+    display: none;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import "@mantine/core/styles.css";
 import { createTheme, MantineProvider } from "@mantine/core";
+// global.css
+import "./globals.css";
 
 export const metadata: Metadata = {
 	title: "数独アプリ",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,8 +7,6 @@ export const config = {
 
 // ミドルウェア関数
 export function middleware(request: NextRequest) {
-	NextResponse.next();
-
 	// 環境変数がproductionでない場合、進行する
 	if (process.env.NODE_ENV !== "production") return NextResponse.next();
 

--- a/src/util/sudoke.ts
+++ b/src/util/sudoke.ts
@@ -100,12 +100,15 @@ const isValid = (
 /**
  * ランダムにセルを削除して数独パズルを作成します。
  * @param {number[][]} board - 完全に埋まった数独盤。
+ * @param {number} attempts - 削除するセルの数。
  */
-const removeCells = (board: number[][]): void => {
+const removeCells = (board: number[][], attempts: number): void => {
 	// const newBoard = board.map((row) => [...row]);
+	const maxAttempts = attempts * 2; // 最大試行回数を設定
+	let newAttempts = attempts;
+	let tries = 0;
 
-	let attempts = 12; // 難易度に応じて調整可能
-	while (attempts > 0) {
+	while (newAttempts > 0 && tries < maxAttempts) {
 		const row = Math.floor(Math.random() * 9);
 		const col = Math.floor(Math.random() * 9);
 		if (board[row][col] !== 0) {
@@ -115,22 +118,13 @@ const removeCells = (board: number[][]): void => {
 			const copy = board.map((row) => [...row]);
 			if (!hasUniqueSolution(copy)) {
 				board[row][col] = backup;
-				attempts--;
+			} else {
+				newAttempts--;
 			}
 		}
+		tries++;
+		// newAttempts--;
 	}
-
-	// let removed = 0;
-	// while (removed < 2) {
-	// 	const row = Math.floor(Math.random() * 9);
-	// 	const col = Math.floor(Math.random() * 9);
-
-	// 	if (newBoard[row][col] !== 0) {
-	// 		newBoard[row][col] = 0;
-	// 		removed++;
-	// 	}
-	// }
-	// return newBoard;
 };
 
 /**
@@ -150,36 +144,39 @@ const hasUniqueSolution = (board: number[][]): boolean => {
  */
 const solveSudokuWithCount = (board: number[][], count: number): number => {
 	const emptyCell = findEmptyCell(board);
-	if (!emptyCell) return count + 1;
+	let newCount = count;
+	if (!emptyCell) return newCount + 1;
 	const [row, col] = emptyCell;
 
 	for (let num = 1; num <= 9; num++) {
 		if (isValid(board, row, col, num)) {
 			board[row][col] = num;
-			count = solveSudokuWithCount(board, count);
+			newCount = solveSudokuWithCount(board, newCount);
 			board[row][col] = 0;
 		}
 	}
-	return count;
+	return newCount;
 };
 
 /**
  * 新しい数独パズルを生成します。
  * @returns {number[][]} 一部のセルが空の生成された数独盤。
  */
-const generateSudoku = (): number[][] => {
+const generateSudoku = (mode: "easy" | "normal" | "hard"): number[][] => {
 	const board = createEmptyBoard();
 	fillBoard(board);
-	removeCells(board);
+
+	let attempts: number;
+	if (mode === "easy") {
+		attempts = 55;
+	} else if (mode === "normal") {
+		attempts = 65;
+	} else {
+		attempts = 75;
+	}
+
+	removeCells(board, attempts);
 	return board;
 };
 
-export {
-	createEmptyBoard,
-	fillBoard,
-	isValid,
-	removeCells,
-	solveSudoku,
-	solveSudokuWithCount,
-	generateSudoku,
-};
+export { isValid, generateSudoku };


### PR DESCRIPTION
ゲーム開始時に難易度設定を追加する

難易度設定を4~5段階にする
難易度から、盤面生成を行う
問題解答中・完了後に、難易度を表示

## 完了条件

- [x] ゲーム開始時に、難易度設定を4~5段階を選択できるようにする
- [x] 難易度から、盤面生成を行う
- [x] 問題解答中・完了後に、難易度を表示


参考: https://github.com/Nao-as/sudoku/issues/1
